### PR TITLE
Add themed login experience for the UNTELS cafeteria

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,14 +13,18 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.ComedorUNTELS">
         <activity
-            android:name=".MainActivity"
-            android:exported="true">
+            android:name=".LoginActivity"
+            android:exported="true"
+            android:theme="@style/Theme.ComedorUNTELS">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".MainActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/pe/edu/untels/comedor/LoginActivity.kt
+++ b/app/src/main/java/pe/edu/untels/comedor/LoginActivity.kt
@@ -1,0 +1,80 @@
+package pe.edu.untels.comedor
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.inputmethod.EditorInfo
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.snackbar.Snackbar
+import pe.edu.untels.comedor.databinding.ActivityLoginBinding
+
+class LoginActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityLoginBinding
+    private lateinit var sessionManager: SessionManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        sessionManager = SessionManager(this)
+
+        if (sessionManager.isLoggedIn()) {
+            navigateToMain()
+            return
+        }
+
+        binding = ActivityLoginBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.etPassword.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                attemptLogin()
+                true
+            } else {
+                false
+            }
+        }
+
+        binding.btnLogin.setOnClickListener {
+            attemptLogin()
+        }
+    }
+
+    private fun attemptLogin() {
+        val username = binding.etUsername.text?.toString()?.trim().orEmpty()
+        val password = binding.etPassword.text?.toString()?.trim().orEmpty()
+
+        var hasError = false
+
+        if (username.isEmpty()) {
+            binding.tilUsername.error = getString(R.string.login_error_required)
+            hasError = true
+        } else {
+            binding.tilUsername.error = null
+        }
+
+        if (password.isEmpty()) {
+            binding.tilPassword.error = getString(R.string.login_error_required)
+            hasError = true
+        } else {
+            binding.tilPassword.error = null
+        }
+
+        if (hasError) return
+
+        val credential = sessionManager.authenticate(username, password)
+
+        if (credential != null) {
+            sessionManager.persistSession(credential)
+            navigateToMain()
+        } else {
+            binding.tilPassword.error = getString(R.string.login_error_invalid)
+            Snackbar.make(binding.root, R.string.login_error_invalid, Snackbar.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun navigateToMain() {
+        startActivity(Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        })
+        finish()
+    }
+}

--- a/app/src/main/java/pe/edu/untels/comedor/MainActivity.kt
+++ b/app/src/main/java/pe/edu/untels/comedor/MainActivity.kt
@@ -1,5 +1,6 @@
 package pe.edu.untels.comedor
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.NestedScrollView
@@ -16,9 +17,17 @@ class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
     private val fragments = mutableMapOf<Int, Fragment>()
     private var currentItemId = R.id.nav_hoy
+    private lateinit var sessionManager: SessionManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        sessionManager = SessionManager(this)
+
+        if (!sessionManager.isLoggedIn()) {
+            navigateToLogin()
+            return
+        }
+
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -82,6 +91,13 @@ class MainActivity : AppCompatActivity() {
                 fragments[itemId] = fragment
             }
         }
+    }
+
+    private fun navigateToLogin() {
+        startActivity(Intent(this, LoginActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        })
+        finish()
     }
 
     companion object {

--- a/app/src/main/java/pe/edu/untels/comedor/SessionManager.kt
+++ b/app/src/main/java/pe/edu/untels/comedor/SessionManager.kt
@@ -1,0 +1,94 @@
+package pe.edu.untels.comedor
+
+import android.content.Context
+import androidx.core.content.edit
+
+class SessionManager(context: Context) {
+
+    private val preferences =
+        context.getSharedPreferences("comedor_session", Context.MODE_PRIVATE)
+
+    private val demoUsers = listOf(
+        UserCredential(
+            username = "estudiante",
+            password = "energia2024",
+            displayName = "Valeria Mendoza",
+            program = "Ing. Ambiental · C0021345",
+            role = "Embajadora del menú saludable"
+        ),
+        UserCredential(
+            username = "nutri",
+            password = "sabores!",
+            displayName = "Equipo de Nutrición",
+            program = "Coordinación UNTELS",
+            role = "Diseño nutricional del comedor"
+        ),
+        UserCredential(
+            username = "admin",
+            password = "solardeli",
+            displayName = "Gestión del Comedor",
+            program = "Administración de Servicios",
+            role = "Coordinación operativa"
+        )
+    )
+
+    fun authenticate(username: String, password: String): UserCredential? {
+        return demoUsers.firstOrNull { credential ->
+            credential.username.equals(username, ignoreCase = true) &&
+                credential.password == password
+        }
+    }
+
+    fun persistSession(credential: UserCredential) {
+        preferences.edit {
+            putBoolean(KEY_IS_LOGGED_IN, true)
+            putString(KEY_USERNAME, credential.username)
+            putString(KEY_DISPLAY_NAME, credential.displayName)
+            putString(KEY_PROGRAM, credential.program)
+            putString(KEY_ROLE, credential.role)
+        }
+    }
+
+    fun isLoggedIn(): Boolean = preferences.getBoolean(KEY_IS_LOGGED_IN, false)
+
+    fun getActiveProfile(): UserProfile? {
+        if (!preferences.contains(KEY_USERNAME)) return null
+        val displayName = preferences.getString(KEY_DISPLAY_NAME, null) ?: return null
+        val program = preferences.getString(KEY_PROGRAM, null) ?: return null
+        val role = preferences.getString(KEY_ROLE, null) ?: return null
+
+        return UserProfile(
+            displayName = displayName,
+            program = program,
+            role = role
+        )
+    }
+
+    fun logout() {
+        preferences.edit {
+            clear()
+        }
+    }
+
+    data class UserCredential(
+        val username: String,
+        val password: String,
+        val displayName: String,
+        val program: String,
+        val role: String
+    )
+
+    data class UserProfile(
+        val displayName: String,
+        val program: String,
+        val role: String
+    )
+
+    private companion object {
+        const val KEY_IS_LOGGED_IN = "key_is_logged_in"
+        const val KEY_USERNAME = "key_username"
+        const val KEY_DISPLAY_NAME = "key_display_name"
+        const val KEY_PROGRAM = "key_program"
+        const val KEY_ROLE = "key_role"
+    }
+}

--- a/app/src/main/java/pe/edu/untels/comedor/ui/PerfilFragment.kt
+++ b/app/src/main/java/pe/edu/untels/comedor/ui/PerfilFragment.kt
@@ -1,22 +1,48 @@
 package pe.edu.untels.comedor.ui
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
+import pe.edu.untels.comedor.LoginActivity
+import pe.edu.untels.comedor.R
+import pe.edu.untels.comedor.SessionManager
 import pe.edu.untels.comedor.databinding.FragmentPerfilBinding
 
 class PerfilFragment : Fragment() {
     private var _binding: FragmentPerfilBinding? = null
     private val binding get() = _binding!!
+    private lateinit var sessionManager: SessionManager
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentPerfilBinding.inflate(inflater, container, false)
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        sessionManager = SessionManager(requireContext())
+
+        sessionManager.getActiveProfile()?.let { profile ->
+            binding.tvNombreUsuario.text = profile.displayName
+            binding.tvCodigo.text = profile.program
+            binding.tvRol.text = profile.role
+        }
+
+        binding.btnCerrarSesion.setOnClickListener {
+            sessionManager.logout()
+            Toast.makeText(requireContext(), R.string.profile_logout_message, Toast.LENGTH_SHORT).show()
+            startActivity(Intent(requireContext(), LoginActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            })
+            requireActivity().finish()
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/res/drawable/ic_cafeteria.xml
+++ b/app/src/main/res/drawable/ic_cafeteria.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <path
+        android:fillColor="#6366F1"
+        android:pathData="M8,5c-1.66,0 -3,1.34 -3,3v12c0,2.21 1.79,4 4,4h4v12h4V5H8zM35,5h-6v31h4v-9h2c4.42,0 8,-3.58 8,-8V13c0,-4.42 -3.58,-8 -8,-8zM39,19c0,2.21 -1.79,4 -4,4h-2v-14h2c2.21,0 4,1.79 4,4v6z" />
+    <path
+        android:fillColor="#EC4899"
+        android:pathData="M15,18h4v22h-4z" />
+    <path
+        android:fillColor="#059669"
+        android:fillAlpha="0.9"
+        android:pathData="M24,28c4.42,0 8,3.58 8,8v4h-4v-4c0,-2.21 -1.79,-4 -4,-4s-4,1.79 -4,4v4h-4v-4c0,-4.42 3.58,-8 8,-8z" />
+</vector>

--- a/app/src/main/res/drawable/ic_logout.xml
+++ b/app/src/main/res/drawable/ic_logout.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#6366F1"
+        android:pathData="M10,3h9c1.1,0 2,0.9 2,2v4h-2V5h-9v14h9v-4h2v4c0,1.1 -0.9,2 -2,2h-9c-1.1,0 -2,-0.9 -2,-2V5c0,-1.1 0.9,-2 2,-2z" />
+    <path
+        android:fillColor="#EC4899"
+        android:pathData="M5.59,7.58L7,9l-2,2h9v2H5l2,2 -1.41,1.41L0.17,12z" />
+</vector>

--- a/app/src/main/res/drawable/login_background.xml
+++ b/app/src/main/res/drawable/login_background.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <gradient
+                android:angle="135"
+                android:centerColor="#F8FAFF"
+                android:endColor="#FEE2F7"
+                android:startColor="#EEF2FF" />
+        </shape>
+    </item>
+    <item android:gravity="top">
+        <shape android:shape="rectangle">
+            <size android:height="420dp" />
+            <gradient
+                android:angle="225"
+                android:endColor="#40EC4899"
+                android:startColor="#406366F1" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/login_background"
+    android:fitsSystemWindows="true"
+    tools:context=".LoginActivity">
+
+    <ImageView
+        android:id="@+id/heroGradient"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@null"
+        android:scaleType="centerCrop"
+        android:src="@drawable/bg_header_gradient"
+        android:alpha="0.32"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/cardLogin"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
+        android:layout_marginTop="64dp"
+        android:layout_marginBottom="32dp"
+        android:backgroundTint="@android:color/transparent"
+        android:elevation="0dp"
+        app:cardCornerRadius="28dp"
+        app:cardUseCompatPadding="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:strokeColor="@color/md_primary_container"
+        app:strokeWidth="1dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="28dp"
+            android:paddingTop="32dp"
+            android:paddingBottom="36dp">
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <com.google.android.material.imageview.ShapeableImageView
+                    android:layout_width="56dp"
+                    android:layout_height="56dp"
+                    android:background="@color/md_primary_container"
+                    android:scaleType="centerInside"
+                    android:src="@drawable/ic_cafeteria"
+                    app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full"
+                    app:strokeColor="@color/md_primary"
+                    app:strokeWidth="1dp" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/login_title"
+                        android:textColor="@color/md_on_surface"
+                        android:textSize="22sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:text="@string/login_tagline"
+                        android:textColor="@color/md_on_surface_variant"
+                        android:textSize="13sp" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <com.google.android.material.divider.MaterialDivider
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginVertical="24dp"
+                app:dividerColor="@color/md_outline" />
+
+            <TextView
+                android:id="@+id/tvBienvenida"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/login_subtitle"
+                android:textColor="@color/md_on_surface"
+                android:textSize="16sp"
+                android:textStyle="medium"
+                android:lineSpacingExtra="2dp" />
+
+            <TextView
+                android:id="@+id/tvHelper"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/login_helper"
+                android:textColor="@color/md_on_surface_variant"
+                android:textSize="12sp" />
+
+            <TextView
+                android:id="@+id/tvDemo"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:background="@drawable/pill_transparent"
+                android:paddingHorizontal="16dp"
+                android:paddingVertical="8dp"
+                android:text="@string/login_demo_hint"
+                android:textColor="@color/md_primary"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilUsername"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="28dp"
+                android:hint="@string/login_user_hint"
+                app:boxStrokeColor="@color/md_primary"
+                app:boxStrokeWidthFocused="2dp"
+                app:endIconMode="clear_text">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etUsername"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:maxLines="1" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilPassword"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:hint="@string/login_password_hint"
+                app:boxStrokeColor="@color/md_primary"
+                app:boxStrokeWidthFocused="2dp"
+                app:endIconMode="password_toggle">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etPassword"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:imeOptions="actionDone"
+                    android:inputType="textPassword"
+                    android:maxLines="1" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/pill_background"
+                    android:paddingHorizontal="14dp"
+                    android:paddingVertical="6dp"
+                    android:text="Menú solar activo"
+                    android:textColor="@color/md_primary"
+                    android:textSize="12sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp"
+                    android:text="Platos inspirados en la energía limpia de Villa El Salvador"
+                    android:textColor="@color/md_on_surface_variant"
+                    android:textSize="12sp"
+                    android:lineSpacingExtra="2dp" />
+            </LinearLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnLogin"
+                style="@style/Widget.Material3.Button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="28dp"
+                android:backgroundTint="@color/md_primary"
+                android:text="@string/login_button"
+                android:textAllCaps="false"
+                android:textSize="16sp"
+                app:cornerRadius="20dp"
+                app:icon="@drawable/ic_arrow_right"
+                app:iconGravity="textEnd"
+                app:iconPadding="12dp"
+                app:iconTint="@color/md_on_primary" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_perfil.xml
+++ b/app/src/main/res/layout/fragment_perfil.xml
@@ -64,7 +64,7 @@
                         android:id="@+id/tvNombreUsuario"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Pablo Huacanjulca"
+                        android:text="Usuario UNTELS"
                         android:textColor="@android:color/white"
                         android:textSize="22sp"
                         android:textStyle="bold" />
@@ -74,7 +74,17 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="4dp"
-                        android:text="Ing. de Sistemas · 2223110056"
+                        android:text="Programa académico"
+                        android:textColor="@android:color/white"
+                        android:textSize="13sp"
+                        android:alpha="0.85" />
+
+                    <TextView
+                        android:id="@+id/tvRol"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:text="Rol gastronómico"
                         android:textColor="@android:color/white"
                         android:textSize="13sp"
                         android:alpha="0.85" />
@@ -569,6 +579,21 @@
                     </LinearLayout>
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnCerrarSesion"
+                style="@style/Widget.Material3.Button.OutlinedButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="28dp"
+                android:text="@string/profile_logout"
+                android:textAllCaps="false"
+                android:textSize="15sp"
+                app:cornerRadius="20dp"
+                app:icon="@drawable/ic_logout"
+                app:iconTint="@color/md_primary"
+                app:strokeColor="@color/md_primary"
+                app:strokeWidth="1dp" />
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">ComedorUNTELS</string>
+
+    <string name="login_title">Bienvenido al Comedor UNTELS</string>
+    <string name="login_tagline">Energía solar para tus ideas y tu alimentación.</string>
+    <string name="login_subtitle">Gestiona tus reservas y mantente conectado con la experiencia gastronómica de la UNTELS.</string>
+    <string name="login_helper">Ingresa con las credenciales asignadas por el equipo del comedor.</string>
+    <string name="login_demo_hint">Demo: estudiante / energia2024</string>
+    <string name="login_user_hint">Usuario UNTELS</string>
+    <string name="login_password_hint">Contraseña</string>
+    <string name="login_button">Ingresar</string>
+    <string name="login_error_required">Este campo es obligatorio</string>
+    <string name="login_error_invalid">Usuario o contraseña incorrectos</string>
+
+    <string name="profile_logout">Cerrar sesión</string>
+    <string name="profile_logout_message">Tu sesión se cerró correctamente.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a themed login activity that validates demo credentials and persists the session with shared preferences
- gate MainActivity behind the new session manager and enrich the profile screen with logout support and dynamic user data
- craft modern login resources, including gradients, icons, and strings, aligned with the UNTELS comedor identity

## Testing
- ./gradlew assembleDebug *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d64640fd2483239ada9e72c500627d